### PR TITLE
remove tax_id and company_id when switching customer groups during registration; password autocomplete admin customer form

### DIFF
--- a/upload/admin/view/template/sale/customer_form.tpl
+++ b/upload/admin/view/template/sale/customer_form.tpl
@@ -64,14 +64,14 @@
               </tr>
               <tr>
                 <td><?php echo $entry_password; ?></td>
-                <td><input type="password" name="password" value="<?php echo $password; ?>"  />
+                <td><input type="password" name="password" autocomplete="new-password" value="<?php echo $password; ?>"  />
                   <?php if ($error_password) { ?>
                   <span class="error"><?php echo $error_password; ?></span>
                   <?php  } ?></td>
               </tr>
               <tr>
                 <td><?php echo $entry_confirm; ?></td>
-                <td><input type="password" name="confirm" value="<?php echo $confirm; ?>" />
+                <td><input type="password" name="confirm" autocomplete="new-password" value="<?php echo $confirm; ?>" />
                   <?php if ($error_confirm) { ?>
                   <span class="error"><?php echo $error_confirm; ?></span>
                   <?php  } ?></td>

--- a/upload/admin/view/template/sale/order_form.tpl
+++ b/upload/admin/view/template/sale/order_form.tpl
@@ -655,6 +655,7 @@ $('select[id=\'customer_group_id\']').live('change', function() {
 		if (customer_group[this.value]['company_id_display'] == '1') {
 			$('#company-id-display').show();
 		} else {
+			document.querySelector('[name="company_id"]').value = '';
 			$('#company-id-display').hide();
 		}
 		
@@ -667,6 +668,7 @@ $('select[id=\'customer_group_id\']').live('change', function() {
 		if (customer_group[this.value]['tax_id_display'] == '1') {
 			$('#tax-id-display').show();
 		} else {
+			document.querySelector('[name="tax_id"]').value = '';
 			$('#tax-id-display').hide();
 		}
 		

--- a/upload/catalog/view/theme/default/template/account/register.tpl
+++ b/upload/catalog/view/theme/default/template/account/register.tpl
@@ -209,6 +209,7 @@ $('input[name=\'customer_group_id\']:checked').live('change', function() {
 		if (customer_group[this.value]['company_id_display'] == '1') {
 			$('#company-id-display').show();
 		} else {
+			document.querySelector('[name="company_id"]').value = '';
 			$('#company-id-display').hide();
 		}
 		
@@ -221,6 +222,7 @@ $('input[name=\'customer_group_id\']:checked').live('change', function() {
 		if (customer_group[this.value]['tax_id_display'] == '1') {
 			$('#tax-id-display').show();
 		} else {
+			document.querySelector('[name="tax_id"]').value = '';
 			$('#tax-id-display').hide();
 		}
 		

--- a/upload/catalog/view/theme/default/template/checkout/guest.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/guest.tpl
@@ -121,6 +121,7 @@ $('#payment-address input[name=\'customer_group_id\']:checked').live('change', f
 		if (customer_group[this.value]['company_id_display'] == '1') {
 			$('#company-id-display').show();
 		} else {
+			document.querySelector('[name="company_id"]').value = '';
 			$('#company-id-display').hide();
 		}
 		
@@ -133,6 +134,7 @@ $('#payment-address input[name=\'customer_group_id\']:checked').live('change', f
 		if (customer_group[this.value]['tax_id_display'] == '1') {
 			$('#tax-id-display').show();
 		} else {
+			document.querySelector('[name="tax_id"]').value = '';
 			$('#tax-id-display').hide();
 		}
 		

--- a/upload/catalog/view/theme/default/template/checkout/register.tpl
+++ b/upload/catalog/view/theme/default/template/checkout/register.tpl
@@ -140,6 +140,7 @@ $('#payment-address input[name=\'customer_group_id\']:checked').live('change', f
 		if (customer_group[this.value]['company_id_display'] == '1') {
 			$('#company-id-display').show();
 		} else {
+			document.querySelector('[name="company_id"]').value = '';
 			$('#company-id-display').hide();
 		}
 		
@@ -152,6 +153,7 @@ $('#payment-address input[name=\'customer_group_id\']:checked').live('change', f
 		if (customer_group[this.value]['tax_id_display'] == '1') {
 			$('#tax-id-display').show();
 		} else {
+			document.querySelector('[name="tax_id"]').value = '';
 			$('#tax-id-display').hide();
 		}
 		


### PR DESCRIPTION
When registering new customer account or checkout, if the customer starts to type inside the input for customer_id or tax_id and then switch to a different group without the requirement, the input field is hidden, but the value will still get sent. If VAT ID check is active and the ID is not valid, this will keep throwing an error. The error is hidden because the customer group hides the DIV so the customer does not know why the button doesn't seem to work.

This change will clear the value when switching to a customer group that does not require customer_id or tax_id.

The other change is to make autocomplete="new-password" in admin customer_form.tpl to stop the browser from entering a password whenever you visit the customer page.