### PR TITLE
touchtap for cart

### DIFF
--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -26,10 +26,24 @@ $(document).ready(function() {
 		}
 	});
 	
+	
 	/* Ajax Cart */
+	$('html').on('touchend.tap', function(){
+  	if ($('#cart').hasClass('active')){
+		$('#cart').removeClass('active')
+	}
+	});
+
+	$('div#cart').on('touchend.tap', function(e){
+	e.stopPropagation();
+	});
+
 	$('#cart > .heading a').live('click', function() {
-		$('#cart').addClass('active');
-		
+		if ($('#cart').hasClass('active')){
+    			$('#cart').removeClass('active')
+		} else {
+			$('#cart').addClass('active');
+		}
 		$('#cart').load('index.php?route=module/cart #cart > *');
 		
 		$('#cart').live('mouseleave', function() {

--- a/upload/catalog/view/javascript/common.js
+++ b/upload/catalog/view/javascript/common.js
@@ -26,7 +26,6 @@ $(document).ready(function() {
 		}
 	});
 	
-	
 	/* Ajax Cart */
 	$('html').on('touchend.tap', function(){
   	if ($('#cart').hasClass('active')){


### PR DESCRIPTION
In stock version, I think the cart stays open when you tap the cart heading and it can't be closed again because it's only for mouse click and mouseleave.

What the first part does is when you tap outside of the cart, then the cart will close.
The second part allows you to close the cart by clicking the cart heading.

I've only tested it on an older version, but the cart doesn't seem to be much different for 1.5.6.5_rc so it should probably also work.


