### PR TITLE
Update utf8.php changed && to || because of logic

### DIFF
--- a/upload/system/helper/utf8.php
+++ b/upload/system/helper/utf8.php
@@ -548,7 +548,7 @@ if (extension_loaded('mbstring')) {
 				$unicode[] = ((ord($string[$i]) - 248) * pow(64, 4) + (ord($string[$i + 1]) - 128) * pow(64, 3) + (ord($string[$i + 2]) - 128) * pow(64, 2) + (ord($string[$i + 3]) - 128) * pow(64, 1) + (ord($string[$i + 4]) - 128) * pow(64, 0));
 			}
 
-			if ($chr == 252 && $chr == 253) {
+			if ($chr == 252 || $chr == 253) {
 				$unicode[] = ((ord($string[$i]) - 252) * pow(64, 5) + (ord($string[$i + 1]) - 128) * pow(64, 4) + (ord($string[$i + 2]) - 128) * pow(64, 3) + (ord($string[$i + 3]) - 128) * pow(64, 2) + (ord($string[$i + 4]) - 128) * pow(64, 1) + (ord($string[$i + 5]) - 128) * pow(64, 0));
 			}
 		}


### PR DESCRIPTION
changed && to || because of logic. copied from the version in 3.0.3.7. Although I don't know what these do.